### PR TITLE
fix(linkedin-api-v2): parse response bodies correctly

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -24,7 +24,38 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
   //LinkedIn uses a custom name for the access_token parameter
   this._oauth2.setAccessTokenName("oauth2_access_token");
+  if (!!this.emailUrl) {
+    var self = this
+    this._oauth2.get(this.emailUrl, accessToken, function (err, body, res) {
+      if (err) {
+        return done(new InternalOAuthError('failed to fetch user email', err));
+      }
 
+      try {
+        var json = JSON.parse(body);
+        var emails = [];
+        var elements = json["elements"];
+        elements.forEach(function (element) {
+          // elements can be both emails and phone numbers
+          // See: https://developer.linkedin.com/docs/guide/v2/people/primary-contact-api
+          // under Retrieve Email Address / Response Body
+          if (element && element["handle"].includes("emailAddress")) {
+            var email = {value: element["handle~"]["emailAddress"]};
+            emails.push(email);
+          }
+        });
+        self._fetchAsyncProfile(accessToken, done, emails);
+
+      } catch (e) {
+        done(e);
+      }
+    });
+  } else {
+    this._fetchAsyncProfile(accessToken, done);
+  }
+};
+
+Strategy.prototype._fetchAsyncProfile = function (accessToken, done, emails) {
   this._oauth2.get(this.profileUrl, accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
 
@@ -33,13 +64,26 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
       var profile = { provider: 'linkedin' };
 
+      // fields are now represented as MultiLocaleString object type
+      // See: https://docs.microsoft.com/en-us/linkedin/shared/references/v2/profile/lite-profile
+      var prefferedLanguage = json.firstName.preferredLocale.language;
+      var prefferedCountry = json.firstName.preferredLocale.country;
+      var prefferedLocaleKey = prefferedLanguage + '_' + prefferedCountry;
+
+
+      var lastName = json["lastName"]["localized"][prefferedLocaleKey];
+      var firstName = json["firstName"]["localized"][prefferedLocaleKey];
+
       profile.id = json.id;
-      profile.displayName = json.formattedName;
+      // display name is not existent anymore
+      // See: https://docs.microsoft.com/en-us/linkedin/shared/references/v2/profile/lite-profile
+      profile.displayName = firstName + ' ' + lastName;
+
       profile.name = {
-                        familyName: json.lastName,
-                        givenName:  json.firstName
-                     };
-      profile.emails = [{ value: json.emailAddress }];
+        familyName: lastName,
+        givenName: firstName
+      };
+      profile.emails = emails || [{value: json.emailAddress}];
       profile.photos = [];
       if (json.pictureUrl) {
           profile.photos.push({ value: json.pictureUrl });
@@ -60,68 +104,25 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 Strategy.prototype._convertScopeToUserProfileFields = function(scope, profileFields) {
   var self = this;
   var map = {
-    'r_basicprofile':   [
+    'r_liteprofile': [
       'id',
-      'first-name',
-      'last-name',
-      'picture-url',
-      'picture-urls::(original)',
-      'formatted-name',
-      'maiden-name',
-      'phonetic-first-name',
-      'phonetic-last-name',
-      'formatted-phonetic-name',
-      'headline',
-      'location:(name,country:(code))',
-      'industry',
-      'distance',
-      'relation-to-viewer:(distance,connections)',
-      'current-share',
-      'num-connections',
-      'num-connections-capped',
-      'summary',
-      'specialties',
-      'positions',
-      'site-standard-profile-request',
-      'api-standard-profile-request:(headers,url)',
-      'public-profile-url'
+      'firstName',
+      'lastName',
+      'profilePicture(displayImage~:playableStreams)'
     ],
-    'r_emailaddress':   ['email-address'],
-    'r_fullprofile':   [
-      'last-modified-timestamp',
-      'proposal-comments',
-      'associations',
-      'interests',
-      'publications',
-      'patents',
-      'languages',
-      'skills',
-      'certifications',
-      'educations',
-      'courses',
-      'volunteer',
-      'three-current-positions',
-      'three-past-positions',
-      'num-recommenders',
-      'recommendations-received',
-      'mfeed-rss-url',
-      'following',
-      'job-bookmarks',
-      'suggestions',
-      'date-of-birth',
-      'member-url-resources:(name,url)',
-      'related-profile-views',
-      'honors-awards'
-    ]
   };
+  var r_emailaddress = 'https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))';
 
   var fields = [];
 
   // To obtain pre-defined field mappings
-  if(Array.isArray(scope) && profileFields === null)
-  {
-    if(scope.indexOf('r_basicprofile') === -1){
-      scope.unshift('r_basicprofile');
+  if (Array.isArray(scope) && profileFields === null) {
+    if (scope.indexOf('r_liteprofile') === -1) {
+      scope.unshift('r_liteprofile');
+    }
+
+    if (scope.indexOf('r_emailaddress') !== -1) {
+      self.emailUrl = r_emailaddress
     }
 
     scope.forEach(function(f) {


### PR DESCRIPTION
@G-T-P has already contributed with this PR:
https://github.com/auth0/passport-linkedin-oauth2/pull/61

The APIs were changed to be on Linkedin V2, but the response bodies were not parsed correctly.